### PR TITLE
[FEAT] 마이페이지 관련 DTO, MyPageService 구현

### DIFF
--- a/src/main/java/com/team1/goorm/domain/dto/CartItemDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/CartItemDto.java
@@ -1,0 +1,18 @@
+package com.team1.goorm.domain.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Data
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CartItemDto {
+    private Long productId;
+    private String productName;
+    private BigDecimal price;
+    private int quantity;
+    private String image;
+}

--- a/src/main/java/com/team1/goorm/domain/dto/MyPageResponseDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/MyPageResponseDto.java
@@ -1,0 +1,16 @@
+package com.team1.goorm.domain.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MyPageResponseDto {
+    private UserInfoDto userInfo;
+    private List<PaymentItemDto> paymentHistory;
+    private List<CartItemDto> cartList;
+}

--- a/src/main/java/com/team1/goorm/domain/dto/OrderPreviewResponseDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/OrderPreviewResponseDto.java
@@ -18,17 +18,6 @@ public class OrderPreviewResponseDto {
     private LocalDateTime createdAt;
     private UserInfoDto userInfo;
 
-    @Getter
-    @Builder
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor
-    public static class UserInfoDto {
-        @NotNull
-        private String name;
-        @NotNull
-        private String email;
-    }
-
     public static OrderPreviewResponseDto from(Order order) {
         return OrderPreviewResponseDto.builder()
                 .orderName(order.getOrderName())

--- a/src/main/java/com/team1/goorm/domain/dto/PaymentItemDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/PaymentItemDto.java
@@ -1,0 +1,20 @@
+package com.team1.goorm.domain.dto;
+
+import com.team1.goorm.domain.entity.OrderStatus;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PaymentItemDto {
+    private String orderNumber;
+    private String orderName;
+    private BigDecimal totalAmount;
+    private OrderStatus orderStatus;
+    private LocalDateTime paymentDate;
+}

--- a/src/main/java/com/team1/goorm/domain/dto/UserInfoDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/UserInfoDto.java
@@ -1,0 +1,15 @@
+package com.team1.goorm.domain.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserInfoDto {
+    @NotNull
+    private String name;
+    @NotNull
+    private String email;
+}

--- a/src/main/java/com/team1/goorm/domain/entity/Payment.java
+++ b/src/main/java/com/team1/goorm/domain/entity/Payment.java
@@ -22,6 +22,10 @@ public class Payment {
     @JoinColumn(name = "order_id")
     private Order order;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
     @Column(name = "payment_key", updatable = false, nullable = false)
     private String paymentKey;
 

--- a/src/main/java/com/team1/goorm/repository/PaymentRepository.java
+++ b/src/main/java/com/team1/goorm/repository/PaymentRepository.java
@@ -1,7 +1,11 @@
 package com.team1.goorm.repository;
 
 import com.team1.goorm.domain.entity.Payment;
+import com.team1.goorm.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    List<Payment> findTop5ByUserOrderByApprovedAtDesc(User user);
 }

--- a/src/main/java/com/team1/goorm/service/MyPageService.java
+++ b/src/main/java/com/team1/goorm/service/MyPageService.java
@@ -1,0 +1,53 @@
+package com.team1.goorm.service;
+
+import com.team1.goorm.domain.dto.CartItemDto;
+import com.team1.goorm.domain.dto.MyPageResponseDto;
+import com.team1.goorm.domain.dto.PaymentItemDto;
+import com.team1.goorm.domain.entity.Payment;
+import com.team1.goorm.domain.entity.User;
+import com.team1.goorm.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+    private final PaymentRepository paymentRepository;
+
+    // TODO: Cart 레포지토리 구현 후 추가
+
+    public MyPageResponseDto buildMyPage(User user) {
+        List<Payment> payments = getPayments(user);
+
+        List<PaymentItemDto> paymentHistory = buildPaymentHistory(payments);
+
+        // TODO: Cart 기능 구현 후 cart 조회 로직 추가 예정
+        List<CartItemDto> cartList = new ArrayList<>();
+
+        return MyPageResponseDto.builder()
+                .paymentHistory(paymentHistory)
+                .cartList(cartList)
+                .build();
+    }
+
+    private List<Payment> getPayments(User user) {
+        return paymentRepository.findTop5ByUserOrderByApprovedAtDesc(user);
+    }
+
+    private List<PaymentItemDto> buildPaymentHistory(List<Payment> payments) {
+        return payments.stream()
+                .map(payment -> PaymentItemDto.builder()
+                            .orderNumber(payment.getOrder().getOrderNumber())
+                            .orderName(payment.getOrder().getOrderName())
+                            .totalAmount(payment.getOrder().getTotalAmount())
+                            .orderStatus(payment.getOrder().getStatus())
+                            .paymentDate(payment.getApprovedAt())
+                            .build()
+                ).toList();
+    }
+}


### PR DESCRIPTION
## 요약

- 마이페이지 응답에 사용될 MyPageResponseDto와 관련 DTO 생성
- MyPageResponseDto를 생성하는 MyPageService 구현

## 관련 이슈

- #17 
- #18 

## 변경 유형

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 리팩토링/개선
- [ ] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)

## 주요 변경점

- OrderPreviewResponseDto 내부에 있던 UserInfoDto를 별도의 클래스로 분리했습니다.
- MyPageResponseDto에 List 형태로 담길 CartItemDto와 PaymentItemDto를 구현했습니다.
- Payment 엔티티에 User 컬럼을 추가했습니다.
- PaymentRepository에 최근 결제내역 5개를 반환하는 findTop5ByUserOrderByApprovedAtDesc 메서드를 추가했습니다.
- Cart 관련 코드는 제외하고 결제내역만 반환하는 MyPageService를 구현했습니다.

## 테스트

- [ ] 유닛/통합 테스트 추가 또는 갱신
- [x] 로컬에서 수동 테스트(브라우저/모바일)
- [ ] 엣지 케이스 확인(빈 값/긴 텍스트/이모지 등)

## 체크리스트

- [x] 트랜잭션 범위 및 readOnly 설정 확인
- [x] null 대신 빈 리스트 반환 확인
- [ ] N+1 쿼리 발생 여부 확인
- [x] DB 스키마 변경에 따른 마이그레이션 확인