### PR TITLE
[FIX] OrderPreview, Payment 관련 엔티티 및 DTO 수정

### DIFF
--- a/src/main/java/com/team1/goorm/domain/dto/OrderPreviewRequestDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/OrderPreviewRequestDto.java
@@ -3,6 +3,7 @@ package com.team1.goorm.domain.dto;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -22,5 +23,7 @@ public class OrderPreviewRequestDto {
         private Long productId;
         @NotNull
         private int quantity;
+        @NotNull
+        private LocalDate departureDate;
     }
 }

--- a/src/main/java/com/team1/goorm/domain/dto/OrderPreviewResponseDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/OrderPreviewResponseDto.java
@@ -5,7 +5,9 @@ import com.team1.goorm.domain.entity.OrderStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -13,29 +15,17 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class OrderPreviewResponseDto {
     private String orderName;
-    private String orderId; // ORD-20260215-1 형태
+    private String orderNumber; // ORD-20260215-1 형태
     private OrderStatus status;
-    private LocalDateTime createdAt;
-    private UserInfoDto userInfo;
+    private List<OrderProductDto> orderProducts;
+    private BigDecimal totalPrice;
 
-    @Getter
-    @Builder
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor
-    public static class UserInfoDto {
-        @NotNull
-        private String name;
-        @NotNull
-        private String email;
-    }
 
     public static OrderPreviewResponseDto from(Order order) {
         return OrderPreviewResponseDto.builder()
                 .orderName(order.getOrderName())
-                .orderId(order.getOrderNumber())
+                .orderNumber(order.getOrderNumber())
                 .status(order.getStatus())
-                .createdAt(order.getCreatedAt())
-                .userInfo(new UserInfoDto(order.getUser().getName(), order.getUser().getEmail()))
                 .build();
     }
 }

--- a/src/main/java/com/team1/goorm/domain/dto/OrderPreviewResponseDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/OrderPreviewResponseDto.java
@@ -1,12 +1,14 @@
 package com.team1.goorm.domain.dto;
 
 import com.team1.goorm.domain.entity.Order;
+import com.team1.goorm.domain.entity.OrderProduct;
 import com.team1.goorm.domain.entity.OrderStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -22,10 +24,17 @@ public class OrderPreviewResponseDto {
 
 
     public static OrderPreviewResponseDto from(Order order) {
+        List<OrderProductDto> orderProducts = new ArrayList<>();
+        for (OrderProduct orderProduct : order.getOrderProducts()) {
+            orderProducts.add(OrderProductDto.from(orderProduct));
+        }
+
         return OrderPreviewResponseDto.builder()
                 .orderName(order.getOrderName())
                 .orderNumber(order.getOrderNumber())
                 .status(order.getStatus())
+                .orderProducts(orderProducts)
+                .totalPrice(order.getTotalAmount())
                 .build();
     }
 }

--- a/src/main/java/com/team1/goorm/domain/dto/OrderProductDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/OrderProductDto.java
@@ -1,0 +1,17 @@
+package com.team1.goorm.domain.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OrderProductDto {
+    private String productName;
+    private String startDate;
+    private String endDate;
+    private BigDecimal price;
+    private int quantity;
+}

--- a/src/main/java/com/team1/goorm/domain/dto/OrderProductDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/OrderProductDto.java
@@ -1,8 +1,12 @@
 package com.team1.goorm.domain.dto;
 
+import com.team1.goorm.domain.entity.Cart;
+import com.team1.goorm.domain.entity.OrderProduct;
+import com.team1.goorm.domain.entity.Product;
 import lombok.*;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -10,8 +14,20 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 public class OrderProductDto {
     private String productName;
-    private String startDate;
-    private String endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private BigDecimal price;
     private int quantity;
+
+    public static OrderProductDto from(OrderProduct orderProduct) {
+        Product product = orderProduct.getProduct();
+
+        return OrderProductDto.builder()
+                .productName(product.getProductName())
+                .startDate(orderProduct.getDepartureDate())
+                .endDate(orderProduct.getDepartureDate().plusDays(product.getNights()))
+                .price(product.getPrice())
+                .quantity(orderProduct.getQuantity())
+                .build();
+    }
 }

--- a/src/main/java/com/team1/goorm/domain/dto/PaymentRequestDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/PaymentRequestDto.java
@@ -11,7 +11,6 @@ import java.util.List;
 @AllArgsConstructor
 public class PaymentRequestDto {
     private String orderId;
-    private List<OrderPreviewRequestDto.ProductItemDto> productItem;
     private BigDecimal totalAmount;
     private String paymentMethod;
 }

--- a/src/main/java/com/team1/goorm/domain/dto/PaymentResponseDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/PaymentResponseDto.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class PaymentResponseDto {
-    private String orderId;
+    private String orderNumber;
     private String paymentKey;
     private OrderStatus status;
     private LocalDateTime requestedAt;
@@ -19,7 +19,7 @@ public class PaymentResponseDto {
 
     public static PaymentResponseDto from(Payment payment) {
         return PaymentResponseDto.builder()
-                .orderId(payment.getOrder().getOrderNumber())
+                .orderNumber(payment.getOrder().getOrderNumber())
                 .paymentKey(payment.getPaymentKey())
                 .status(payment.getOrder().getStatus())
                 .requestedAt(payment.getOrder().getCreatedAt())

--- a/src/main/java/com/team1/goorm/domain/entity/OrderProduct.java
+++ b/src/main/java/com/team1/goorm/domain/entity/OrderProduct.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -22,9 +23,9 @@ public class OrderProduct {
     @JoinColumn(name = "order_id")
     private Order order;
 
-    // Product Entity가 없는 관계로 product id 조인 생략
-    // 추후 Product Entity 작성 완료 시 수정
-    private Long productId;
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    private Product product;
 
     // 사용자가 담은 상품 수
     @Column(name = "quantity")
@@ -34,14 +35,19 @@ public class OrderProduct {
     @Column(name = "price")
     private BigDecimal price;
 
+    // 출발 날짜
+    @Column(name = "departure_date")
+    private LocalDate departureDate;
+
     /** 주문 연결 메서드 */
     public void setOrder(Order order) {
         this.order = order;
     }
 
-    public OrderProduct(Long productId, int quantity, BigDecimal price) {
-        this.productId = productId;
+    public OrderProduct(Product product, int quantity, BigDecimal price, LocalDate departureDate) {
+        this.product = product;
         this.quantity = quantity;
         this.price = price;
+        this.departureDate = departureDate;
     }
 }

--- a/src/main/java/com/team1/goorm/service/OrderService.java
+++ b/src/main/java/com/team1/goorm/service/OrderService.java
@@ -9,6 +9,7 @@ import com.team1.goorm.domain.dto.PaymentResponseDto;
 import com.team1.goorm.domain.entity.*;
 import com.team1.goorm.repository.OrderRepository;
 import com.team1.goorm.repository.PaymentRepository;
+import com.team1.goorm.repository.ProductRepository;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.Id;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -27,6 +29,7 @@ import java.util.*;
 public class OrderService {
     private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
+    private final ProductRepository productRepository;
 
     @Transactional
     public OrderPreviewResponseDto createOrder(OrderPreviewRequestDto requestDto, User user) {
@@ -35,7 +38,7 @@ public class OrderService {
                 .user(user)
                 .status(OrderStatus.READY)
                 .createdAt(LocalDateTime.now())
-                .orderNumber("temp_id")
+                .orderNumber("temp_order_number")
                 .build();
         Order savedOrder = orderRepository.save(order);
 
@@ -49,7 +52,7 @@ public class OrderService {
 
         // 상품 가격 계산을 위한 Map 생성(key - id, value - Product)
         Map<Long, Product> productMap = new HashMap<>();
-        products.forEach(product -> productMap.put(product.getId(), product));
+        products.forEach(product -> productMap.put(product.getProductId(), product));
 
         // 상품의 총 가격 계산
         BigDecimal totalAmount = BigDecimal.ZERO;
@@ -62,7 +65,9 @@ public class OrderService {
 
             totalAmount = totalAmount.add(product.getPrice().multiply(BigDecimal.valueOf(itemDto.getQuantity())));
 
-            orderProducts.add(new OrderProduct(product.getId(), itemDto.getQuantity(), product.getPrice()));
+            LocalDate departure = itemDto.getDepartureDate();
+
+            orderProducts.add(new OrderProduct(product, itemDto.getQuantity(), product.getPrice(), departure));
         }
 
         // 임시 저장된 주문 업데이트
@@ -101,7 +106,7 @@ public class OrderService {
 
     // 주문명 생성 메서드
     private String createOrderName(List<Product> products) {
-        String mainProductName = products.getFirst().getName();
+        String mainProductName = products.getFirst().getProductName();
         String orderName = products.size() > 1
                 ? mainProductName + " 외 " + (products.size() - 1) + "건"
                 : mainProductName;
@@ -137,22 +142,11 @@ public class OrderService {
         }
     }
 
-    // 나중에 진짜 Repo로 교체할 메서드
+    // 주문의 상품들을 찾는 메서드
     private List<Product> getProducts(List<Long> ids) {
         return ids.stream()
-                .map(id -> new Product(id, "임시 상품 " + id, new BigDecimal("10000.00")))
+                .map(id -> productRepository.findById(id)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REQUEST)))
                 .toList();
-    }
-
-    // 임시 Product 엔티티
-    @Entity
-    @Getter
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    @AllArgsConstructor
-    public static class Product {
-        @Id
-        private Long id;
-        private String name;
-        private BigDecimal price;
     }
 }

--- a/src/test/java/com/team1/goorm/controller/OrderControllerTests.java
+++ b/src/test/java/com/team1/goorm/controller/OrderControllerTests.java
@@ -110,14 +110,13 @@ public class OrderControllerTests {
         // Request DTO
         PaymentRequestDto requestDto = PaymentRequestDto.builder()
                 .orderId("ORD-20260215-1")
-                .productItem(List.of(item1, item2))
                 .paymentMethod("CARD")
                 .totalAmount(new BigDecimal("30000.00"))
                 .build();
 
         // 서비스가 리턴할 Response DTO
         PaymentResponseDto responseDto = PaymentResponseDto.builder()
-                .orderId("ORD-20260216-1")
+                .orderNumber("ORD-20260216-1")
                 .paymentKey("PAY-METHOD-CARD-XYZ123") // 서비스에서 생성될 포맷 상상
                 .status(OrderStatus.DONE) // order.markAsDone() 반영 결과
                 .requestedAt(LocalDateTime.now())
@@ -137,7 +136,7 @@ public class OrderControllerTests {
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("PAYMENT_SUCCESS"))
-                .andExpect(jsonPath("$.data.order_id").value("ORD-20260216-1"))
+                .andExpect(jsonPath("$.data.order_number").value("ORD-20260216-1"))
                 .andExpect(jsonPath("$.data.status").value("DONE")) // 상태 변경 확인
                 .andDo(print());
     }

--- a/src/test/java/com/team1/goorm/controller/OrderControllerTests.java
+++ b/src/test/java/com/team1/goorm/controller/OrderControllerTests.java
@@ -27,6 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -55,11 +56,13 @@ public class OrderControllerTests {
         OrderPreviewRequestDto.ProductItemDto item1 = OrderPreviewRequestDto.ProductItemDto.builder()
                 .productId(1L)
                 .quantity(1)
+                .departureDate(LocalDate.parse("2026-02-18"))
                 .build();
 
         OrderPreviewRequestDto.ProductItemDto item2 = OrderPreviewRequestDto.ProductItemDto.builder()
                 .productId(5L)
                 .quantity(2)
+                .departureDate(LocalDate.parse("2026-02-18"))
                 .build();
 
         OrderPreviewRequestDto requestDto = OrderPreviewRequestDto.builder()
@@ -67,7 +70,7 @@ public class OrderControllerTests {
                 .build();
         
         OrderPreviewResponseDto responseDto = OrderPreviewResponseDto.builder()
-                .orderId("ORD-20260216-1")
+                .orderNumber("ORD-20260218-1")
                 .orderName("임시 상품 1 외 1건")
                 .status(OrderStatus.READY)
                 .build();
@@ -84,9 +87,8 @@ public class OrderControllerTests {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(requestDto)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data.order_id").value("ORD-20260216-1"))
+                .andExpect(jsonPath("$.data.order_number").value("ORD-20260218-1"))
                 .andDo(print());
-
     }
 
     @Test

--- a/src/test/java/com/team1/goorm/service/OrderServiceTests.java
+++ b/src/test/java/com/team1/goorm/service/OrderServiceTests.java
@@ -6,12 +6,10 @@ import com.team1.goorm.domain.dto.OrderPreviewRequestDto;
 import com.team1.goorm.domain.dto.OrderPreviewResponseDto;
 import com.team1.goorm.domain.dto.PaymentRequestDto;
 import com.team1.goorm.domain.dto.PaymentResponseDto;
-import com.team1.goorm.domain.entity.Order;
-import com.team1.goorm.domain.entity.OrderStatus;
-import com.team1.goorm.domain.entity.Payment;
-import com.team1.goorm.domain.entity.User;
+import com.team1.goorm.domain.entity.*;
 import com.team1.goorm.repository.OrderRepository;
 import com.team1.goorm.repository.PaymentRepository;
+import com.team1.goorm.repository.ProductRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,6 +38,9 @@ public class OrderServiceTests {
     @Mock
     private PaymentRepository paymentRepository;
 
+    @Mock
+    private ProductRepository productRepository;
+
     @InjectMocks
     private OrderService orderService;
 
@@ -53,8 +55,14 @@ public class OrderServiceTests {
     @DisplayName("주문 미리보기 생성 성공")
     void testCreateOrder() {
         // Given
-        OrderPreviewRequestDto.ProductItemDto item1 = new OrderPreviewRequestDto.ProductItemDto(1L, 2); // 10000 * 2
-        OrderPreviewRequestDto.ProductItemDto item2 = new OrderPreviewRequestDto.ProductItemDto(2L, 1); // 10000 * 1
+        Product mockProduct1 = new Product(1L, "임시상품1", new BigDecimal("10000.00"), null, null, null, null, null, 2);
+        Product mockProduct2 = new Product(2L, "임시상품2", new BigDecimal("10000.00"), null, null, null, null, null, 2);
+
+        given(productRepository.findById(1L)).willReturn(Optional.of(mockProduct1));
+        given(productRepository.findById(2L)).willReturn(Optional.of(mockProduct2));
+
+        OrderPreviewRequestDto.ProductItemDto item1 = new OrderPreviewRequestDto.ProductItemDto(1L, 2, LocalDate.parse("2026-02-18")); // 10000 * 2
+        OrderPreviewRequestDto.ProductItemDto item2 = new OrderPreviewRequestDto.ProductItemDto(2L, 1, LocalDate.parse("2026-02-18")); // 10000 * 1
         OrderPreviewRequestDto requestDto = new OrderPreviewRequestDto(List.of(item1, item2));
 
         Order tempOrder = Order.builder().id(100L).user(mockUser).build();
@@ -67,7 +75,8 @@ public class OrderServiceTests {
 
         // Then
         assertThat(result.getOrderName()).contains("외 1건");
-        assertThat(result.getOrderId()).startsWith("ORD-");
+        assertThat(result.getOrderNumber()).startsWith("ORD-");
+        assertThat(result.getOrderProducts().getFirst().getStartDate()).isEqualTo(LocalDate.of(2026, 2, 18));
         verify(orderRepository, times(1)).save(any(Order.class));
     }
 


### PR DESCRIPTION
## 요약

- 출발일 필드의 생성으로 인한 수정

## 관련 이슈

- Closes #20 

## 변경 유형

- [ ] 버그 수정
- [ ] 기능 추가
- [x] 리팩토링/개선
- [ ] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)

## 주요 변경점

- OrderProduct 수정
    - departureDate 필드 추가
    - Product 필드와 연결
- OrderService 수정
    - ProductRepository 주입
    - OrderProduct 생성 로직 변경
- OrderProductDto 생성
    - 상품명, 출발일, 종료일, 가격, 인원수 필드 추가
- OrderPreviewRequestDto 수정
    - departureDate 필드 추가
- OrderPreviewResponseDto 수정
    - OrderProductDto의 리스트 반환
- PaymentRequestDto 수정
    - 주문의 상품 리스트 제거
- OrderService, OrderController 관련 테스트 수정

## 테스트

- [ ] 유닛/통합 테스트 추가 또는 갱신
- [x] 로컬에서 수동 테스트(브라우저/모바일)
- [ ] 엣지 케이스 확인(빈 값/긴 텍스트/이모지 등)

## 체크리스트

- [ ] 접근성 고려(키보드/스크린리더)
- [ ] i18n/문구 검토(한국어 자연스러움)
- [ ] 안전/모더레이션 정책 영향 검토(해당 시)
- [ ] 변경 로그/문서 업데이트