### PR TITLE
[UPDATE] 각각의 이미지를 배열의 형태로 변경하여 사용자에게 제공해주도록 수정

### DIFF
--- a/src/main/java/com/team1/goorm/domain/dto/ProductDetailDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/ProductDetailDto.java
@@ -4,6 +4,7 @@ import com.team1.goorm.domain.entity.Product;
 import lombok.*;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -12,8 +13,9 @@ import java.math.BigDecimal;
 public class ProductDetailDto {
     private String productName; // 상품 이름
     private BigDecimal price; // 상품 가격
-    private String image; // 상품 이미지
-    private String image2; // 상품 이미지 2
+//    private String image; // 상품 이미지
+//    private String image2; // 상품 이미지 2
+    private List<String> images;
     private String addr; // 상품 주소
     private String description; // 상품 설명
     private String category; // 상품 카테고리
@@ -24,8 +26,9 @@ public class ProductDetailDto {
         return ProductDetailDto.builder()
                 .productName(product.getProductName())
                 .price(product.getPrice())
-                .image(product.getImage())
-                .image2(product.getImage2())
+//                .image(product.getImage())
+//                .image2(product.getImage2())
+                .images(List.of(product.getImage(), product.getImage2()))
                 .addr(product.getAddr())
                 .description(product.getDescription())
                 .category(product.getCategory())


### PR DESCRIPTION
## 요약

- 상품 상세 조회 API에서 이미지 필드인 image, image2를 images 배열로 통합했습니다.

## 관련 이슈

- #27 

## 변경 유형

- [ ] 버그 수정
- [ ] 기능 추가
- [x] 리팩토링/개선
- [ ] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)

## 주요 변경점

- `ProductDetailDto`의 `image`, `image2` 필드를 `images: List<String>`으로 변경
- `fromEntity()`에서 두 이미지를 배열로 합침

## 테스트

- [x] 로컬에서 수동 테스트(브라우저/모바일)
