### PR TITLE
[FIX] Hibernate 옵션 제거

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,4 +4,6 @@ spring.datasource.password=${DB_PASSWORD}
 
 external.api.tour.service-key=${TOUR_API_KEY}
 
+spring.jpa.hibernate.ddl-auto=none
+
 server.port=${PORT:8080}


### PR DESCRIPTION
## 요약

- application-prod.properties에 hibernate.ddl-auto 옵션을 none으로 설정했습니다.

## 관련 이슈

- Closes #33 

## 변경 유형

- [ ] 버그 수정
- [x] 기능 추가
- [x] 리팩토링/개선
- [ ] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)

## 주요 변경점

- application-prod.properties에 hibernate.ddl-auto 옵션을 none으로 설정했습니다.

## 테스트

- [ ] 유닛/통합 테스트 추가 또는 갱신
- [x] 로컬에서 수동 테스트(브라우저/모바일)
- [ ] 엣지 케이스 확인(빈 값/긴 텍스트/이모지 등)

## 체크리스트

- [x] 옵션이 none으로 잘 설정되었음