### PR TITLE
[FIX] CartResponseDto에 productId 필드 추가

### DIFF
--- a/src/main/java/com/team1/goorm/domain/dto/CartResponseDto.java
+++ b/src/main/java/com/team1/goorm/domain/dto/CartResponseDto.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 @Builder
 public class CartResponseDto {
     private Long cartId;
+    private Long productId;
     private String productName; // 상품 이름
     private BigDecimal price; // 상품 가격
     private int quantity; // 상품 갯수
@@ -31,6 +32,7 @@ public class CartResponseDto {
 
         return CartResponseDto.builder()
                 .cartId(cart.getCartId())
+                .productId(cart.getProduct().getProductId())
                 .productName(cart.getProduct().getProductName())
                 .price(cart.getProduct().getPrice())
                 .quantity(cart.getQuantity())


### PR DESCRIPTION
## 요약

- 장바구니 조회 응답에 `productId`가 없어 주문을 생성할 수 없었습니다. 따라서 `CartResponseDto`에 `productId` 필드를 추가하였습니다.

## 관련 이슈

- #37 

## 변경 유형

- [ ] 버그 수정
- [ ] 기능 추가
- [x] 리팩토링/개선
- [ ] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)

## 주요 변경점

- `CartResponseDto`에 `productID` 필드 추가
- `fromEntity()`에 `cart.getProduct().getProductId()`를 통해 `productId`매핑

## 테스트

- [x] 로컬에서 수동 테스트(브라우저/모바일)

<img width="528" height="247" alt="스크린샷 2026-03-01 오전 11 16 01" src="https://github.com/user-attachments/assets/f178277a-45c9-42c9-9cdd-158788f3c806" />

