### PR TITLE
[FIX] CORS 배포 주소 추가

### DIFF
--- a/src/main/java/com/team1/goorm/config/CorsConfig.java
+++ b/src/main/java/com/team1/goorm/config/CorsConfig.java
@@ -18,7 +18,8 @@ public class CorsConfig {
                         .allowedOrigins(
                                 "http://localhost:3000",
                                 "http://localhost:5173",
-                                "http://localhost:8080"
+                                "http://localhost:8080",
+                                "https://goorm-trip-front.vercel.app"
                         )
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
                         .allowedHeaders("*")


### PR DESCRIPTION
## 요약

- CORS 허용 주소에 vercel 배포 주소를 추가했습니다.

## 관련 이슈

- #39 

## 변경 유형

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 리팩토링/개선
- [ ] 테스트
- [ ] 문서
- [ ] 작업 중(WIP)

## 주요 변경점

- `allowedOrigins`에 `"https://goorm-trip-front.vercel.app"`를  추가했습니다.

